### PR TITLE
Now possible to set meta params.

### DIFF
--- a/lib/omniauth/strategies/coinbase.rb
+++ b/lib/omniauth/strategies/coinbase.rb
@@ -13,6 +13,8 @@ module OmniAuth
                 :cert_store => ::Coinbase::Client.whitelisted_cert_store
               }
       }
+      option :authorize_options, [:scope, :meta]
+
 
       uid { raw_info['id'] }
 


### PR DESCRIPTION
Meta params are ignored when setting up the coinbase strategy as they were excluded from authorized_options. Meta parameters are important to the security of the coinbase api because they include params to set spending limits such as 'send_limit_amount'. See https://www.coinbase.com/docs/api/permissions

In this change we add meta params to the coinbase strategy so that they are no longer ignored.

For instance the following code snippet now works: 
  config.omniauth :coinbase, 
    CLIENT_ID,
    CLIENT_SECRET,
    scope: 'user send', meta: {send_limit_amount: '100', send_limit_currency: 'USD', send_limit_period: 'per_day'}
