### PR TITLE
Hacked sandbox support.

### DIFF
--- a/lib/omniauth/strategies/coinbase.rb
+++ b/lib/omniauth/strategies/coinbase.rb
@@ -31,7 +31,11 @@ module OmniAuth
       end
 
       def raw_info
-        @raw_info ||= MultiJson.load(access_token.get('/api/v1/users').body)['users'][0]['user']
+        # Hack to get sandbox to work
+        sandbox = access_token.client.site === "https://sandbox.coinbase.com"
+        access_token.client.site = "https://api.sandbox.coinbase.com" if sandbox
+        user_info_path = "#{sandbox ? nil : '/api'}/v1/users/self"
+        @raw_info ||= MultiJson.load(access_token.get(user_info_path).body)['user']
       rescue ::Errno::ETIMEDOUT
         raise ::Timeout::Error
       end


### PR DESCRIPTION
You can almost use the new sandbox working by setting up omniauth like this:

```ruby
Rails.application.config.middleware.use OmniAuth::Builder do
  provider :coinbase, Settings.coinbase_client_id, Rails.application.secrets.coinbase_client_secret,
    scope: 'user', client_options: {site: 'https://sandbox.coinbase.com'}
end
```
But omniauth-coinbase tries to fetch the current user info from 'https://sandbox.coinbase.com/api/v1/user' which doesnt seem to exist, we need to use 'https://api.sandbox.coinbase.com/v1/user' when using the sandbox. 

This patch fixes the problem in a slightly hacky way. 
