### PR TITLE
Add account option to OAuth Strategy

### DIFF
--- a/lib/omniauth/strategies/coinbase.rb
+++ b/lib/omniauth/strategies/coinbase.rb
@@ -27,7 +27,7 @@ module OmniAuth
                 :cert_store => ::Coinbase::Wallet::APIClient.whitelisted_certificates
               }
       }
-      option :authorize_options, [:scope, :meta]
+      option :authorize_options, [:scope, :meta, :account]
 
       uid { raw_info.id }
 


### PR DESCRIPTION
Coinbase Connect applications can request different access to user’s wallets. This access is defined by account parameter on OAuth2 authorization URL. Available options are:

- **select** (default) Allow user to pick the wallet associated with the application
- **new** Application will create a new wallet (named after the application)
- **all** Application will get access to all of user’s wallets

Reference: https://developers.coinbase.com/docs/wallet/coinbase-connect/permissions