### PR TITLE
Removed now defunct sandbox mode and added layout, referral, and account options

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,20 +56,3 @@ auth.info.name # "Alex Ianus"
 auth.extra.raw_info.email # "aianus@example.com", only present with wallet:user:email scope
 auth.extra.raw_info.time_zone # "Pacific Time (US & Canada)", only present with wallet:user:show scope
 ```
-
-# Sandbox support
-
-Use omniauth-coinbase in development with our [developer sandbox](https://developers.coinbase.com/blog/2015/02/20/sandbox)
-
-Note that you will need to create a separate sandbox OAuth application with its own client_id and secret.
-
-```ruby
-Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :coinbase, ENV["COINBASE_CLIENT_ID"], ENV["COINBASE_CLIENT_SECRET"], scope: 'wallet:user:read', sandbox: true
-end
-```
-
-```ruby
-require 'coinbase/wallet'
-client = Coinbase::Wallet::Client.new(api_key: <sandbox api key>, api_secret: <sandbox api secret>, api_url: "https://api.sandbox.coinbase.com")
-```

--- a/lib/omniauth-coinbase/version.rb
+++ b/lib/omniauth-coinbase/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Coinbase
-    VERSION = "2.1.1"
+    VERSION = "2.1.2"
   end
 end

--- a/lib/omniauth/strategies/coinbase.rb
+++ b/lib/omniauth/strategies/coinbase.rb
@@ -20,7 +20,7 @@ module OmniAuth
                 :cert_store => ::Coinbase::Wallet::APIClient.whitelisted_certificates
               }
       }
-      option :authorize_options, [:scope, :layout, :account, :meta]
+      option :authorize_options, [:scope, :layout, :account, :referral, :meta]
 
       uid { raw_info.id }
 

--- a/lib/omniauth/strategies/coinbase.rb
+++ b/lib/omniauth/strategies/coinbase.rb
@@ -4,12 +4,6 @@ require 'coinbase/wallet'
 module OmniAuth
   module Strategies
     class Coinbase < OmniAuth::Strategies::OAuth2
-      SANDBOX_URLS = {
-        :site => 'https://sandbox.coinbase.com',
-        :api => 'https://api.sandbox.coinbase.com',
-        :authorize_url => 'https://sandbox.coinbase.com/oauth/authorize',
-        :token_url => 'https://sandbox.coinbase.com/oauth/token',
-      }
       PRODUCTION_URLS = {
         :site => 'https://www.coinbase.com',
         :api => 'https://api.coinbase.com',
@@ -19,7 +13,6 @@ module OmniAuth
 
       # Options
       option :name, 'coinbase'
-      option :sandbox, false
       option :client_options, {
               :proxy => ENV['http_proxy'] ? URI(ENV['http_proxy']) : nil,
               :ssl => {
@@ -43,7 +36,7 @@ module OmniAuth
       end
 
       def raw_info
-        client = ::Coinbase::Wallet::OAuthClient.new(access_token: access_token.token, api_url: options.sandbox ? SANDBOX_URLS[:api] : PRODUCTION_URLS[:api])
+        client = ::Coinbase::Wallet::OAuthClient.new(access_token: access_token.token, api_url: PRODUCTION_URLS[:api])
         @raw_info ||= client.current_user
       rescue ::Errno::ETIMEDOUT
         raise ::Timeout::Error
@@ -60,7 +53,7 @@ module OmniAuth
       end
 
       def load_coinbase_urls
-        options.client_options = (options.sandbox ? SANDBOX_URLS : PRODUCTION_URLS).merge(options.client_options)
+        options.client_options = (PRODUCTION_URLS).merge(options.client_options)
       end
 
       def callback_url

--- a/lib/omniauth/strategies/coinbase.rb
+++ b/lib/omniauth/strategies/coinbase.rb
@@ -20,7 +20,7 @@ module OmniAuth
                 :cert_store => ::Coinbase::Wallet::APIClient.whitelisted_certificates
               }
       }
-      option :authorize_options, [:scope, :meta]
+      option :authorize_options, [:scope, :layout, :account, :meta]
 
       uid { raw_info.id }
 


### PR DESCRIPTION
This PR removes the no longer used sandbox mode and adds options for layout, referral, and account. See [here](https://developers.coinbase.com/docs/wallet/coinbase-connect/reference) for more about these new options.